### PR TITLE
feat: interactive setup wizard with Windsurf support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to Contextify are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Interactive setup wizard — `install.sh` now asks which AI tools to configure
+- Windsurf support (MCP via `~/.codeium/windsurf/mcp_config.json`)
+- `--tools`, `--all`, `--status`, `--help` flags for non-interactive usage
+- Re-runnability — wizard skips already-completed steps on subsequent runs
+- Per-tool status indicators (`✓ configured`, `◐ partial`, `○ not configured`)
+- Auto-restart for Cursor and Windsurf after configuration to load MCP servers
+- `prompts/windsurf.md` template
+
+### Changed
+- `install.sh` no longer auto-detects and silently configures all tools
+- Gemini configuration is now an explicit selection (not always copied)
+
+### Removed
+- Auto-detect behavior (`detect_tools()`) replaced by interactive selection
+
+## [0.2.0] - 2026-02-11
+
+### Added
+- All-in-one Docker image with PostgreSQL, Ollama, and server bundled
+- Production-quality Web UI with redesigned design system
+- Auto-context system with `install.sh` for one-command setup
+- Claude Code hooks (SessionStart, PostToolUse) for automatic memory loading
+- Cursor MCP configuration and rules file support
+- Gemini REST API prompt template
+- `install.sh --uninstall` for clean removal
+- JSON merge utilities (`scripts/lib/json-merge.sh`) with jq/python3 fallback
+- Backend, Web UI, and .github restriction CI workflows
+
+### Changed
+- Merged Web UI into single Docker image (was separate service)
+
+## [0.1.0] - 2026-01-20
+
+### Added
+- Unified AI agent memory system with PostgreSQL + pgvector
+- MCP server (Streamable HTTP transport) for Claude Code and Cursor
+- REST API for Gemini, Antigravity, and other tools
+- Semantic search via Ollama embeddings (nomic-embed-text, 768d)
+- Memory model with types, scopes, importance, and TTL
+- Auto-promotion (importance >= 0.8 or access count >= 5)
+- Background TTL cleanup scheduler
+- Relationship system for linking memories
+- Docker image publishing and CI/CD pipeline
+- Architecture documentation
+
+[Unreleased]: https://github.com/atakanatali/contextify/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/atakanatali/contextify/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/atakanatali/contextify/releases/tag/v0.1.0

--- a/prompts/windsurf.md
+++ b/prompts/windsurf.md
@@ -1,0 +1,34 @@
+# Contextify Memory System
+
+You have access to Contextify, a shared memory system via MCP tools. Use it proactively.
+
+## Session Start
+At the beginning of each session, call `get_context` with the current workspace path as `project_id`.
+
+## When to Store Memories
+Store memories automatically when you:
+- Fix a bug -> type: "fix", importance: 0.7+
+- Discover a pattern -> type: "code_pattern", importance: 0.6+
+- Make an architecture decision -> type: "decision", importance: 0.8
+- Resolve an error -> type: "error" + "solution"
+- Establish a workflow -> type: "workflow", importance: 0.5+
+
+## When to Recall
+Before tackling problems, call `recall_memories` with a natural language description.
+Before making decisions, search for prior decisions on the same topic.
+
+## Required Fields
+- **title**: Specific, searchable (e.g., "Fix: connection timeout in auth service")
+- **content**: Detailed with context
+- **type**: solution | problem | code_pattern | fix | error | workflow | decision | general
+- **importance**: 0.8+ permanent, 0.5-0.7 standard, 0.3-0.4 minor
+- **tags**: [project-name, technology, category]
+- **agent_source**: "windsurf"
+- **project_id**: Current workspace root path
+- **scope**: "project" for project-specific, "global" for cross-project
+
+## Relationships
+Link related memories when possible:
+- solution SOLVES problem
+- fix ADDRESSES error
+- pattern RELATED_TO pattern


### PR DESCRIPTION
## Summary
- Convert `install.sh` from silent auto-detect to an **interactive setup wizard** that asks users which AI tools to configure
- Add **Windsurf** as 4th supported tool (Claude Code, Cursor, Windsurf, Gemini)
- Add **CHANGELOG.md** with full version history
- Update **README.md** Quick Start to lead with the wizard experience

## What changed

### `install.sh` — Interactive Setup Wizard
- Replaced `detect_tools()` auto-detect with interactive numbered menu (1-4)
- Shows per-tool status: `✓ configured` / `◐ partial` / `○ not configured`
- Re-runnable: skips already-completed steps on subsequent runs
- CLI flags: `--tools claude-code,cursor` / `--all` / `--status` / `--help`
- Auto-restart: Cursor and Windsurf get restarted after config to load MCP servers
- Claude Code: warns user to start a new session (CLI can't be restarted programmatically)

### Windsurf support
- MCP config: `~/.codeium/windsurf/mcp_config.json` (uses `serverUrl` key)
- Rules: `~/.codeium/windsurf/memories/contextify.md`
- New template: `prompts/windsurf.md`
- Uninstall cleans up Windsurf configs

### `README.md`
- Quick Start now leads with `./install.sh` wizard (with inline UI example)
- Added `--tools`, `--all`, `--status` documentation
- Windsurf added to Mermaid architecture diagram
- Windsurf added to Manual Agent Setup section

### `CHANGELOG.md`
- Keep a Changelog format with semver
- Documents: Unreleased, v0.2.0, v0.1.0

## Test plan
- [ ] `./install.sh --help` — shows usage
- [ ] `./install.sh --status` — shows Docker + tool status
- [ ] `./install.sh` — interactive wizard works, shows menu
- [ ] `./install.sh --tools cursor` — non-interactive, only configures Cursor
- [ ] `./install.sh --all` — configures all 4 tools
- [ ] Re-run: all steps show "skipping"
- [ ] `./install.sh --uninstall` — removes all configs including Windsurf
- [ ] Invalid tool: `./install.sh --tools foobar` — error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)