### PR TITLE
feat: analytics dashboard, memory type expansion & update mechanism

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -225,6 +225,16 @@ func (h *Handlers) PromoteMemory(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "promoted", "id": id.String()})
 }
 
+// GET /api/v1/analytics
+func (h *Handlers) GetAnalytics(w http.ResponseWriter, r *http.Request) {
+	data, err := h.svc.GetAnalytics(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, data)
+}
+
 // Health check
 func (h *Handlers) Health(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -50,8 +50,9 @@ func NewRouter(svc *memory.Service) *chi.Mux {
 		// Relationships
 		r.Post("/relationships", h.CreateRelationship)
 
-		// Stats
+		// Stats & Analytics
 		r.Get("/stats", h.GetStats)
+		r.Get("/analytics", h.GetAnalytics)
 
 		// Context
 		r.Post("/context/{project}", h.GetContext)

--- a/internal/db/migrations/002_add_memory_types.sql
+++ b/internal/db/migrations/002_add_memory_types.sql
@@ -1,0 +1,9 @@
+-- no-transaction
+-- Add new memory types for cross-agent compatibility
+-- Agents like memorygraph, Cursor, Windsurf may send types not in the original enum
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'task';
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'technology';
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'command';
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'file_context';
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'conversation';
+ALTER TYPE memory_type ADD VALUE IF NOT EXISTS 'project';

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -17,7 +17,7 @@ type StoreMemoryInput struct {
 	Title       string   `json:"title" jsonschema:"Title of the memory,required"`
 	Content     string   `json:"content" jsonschema:"Detailed content of the memory,required"`
 	Summary     *string  `json:"summary,omitempty" jsonschema:"Brief summary"`
-	Type        string   `json:"type" jsonschema:"Type: solution|problem|code_pattern|fix|error|workflow|decision|general"`
+	Type        string   `json:"type" jsonschema:"Type: solution|problem|code_pattern|fix|error|workflow|decision|general|task|technology|command|file_context|conversation|project. Unknown types default to general."`
 	Scope       string   `json:"scope" jsonschema:"Scope: global|project"`
 	ProjectID   *string  `json:"project_id,omitempty" jsonschema:"Project identifier"`
 	AgentSource *string  `json:"agent_source,omitempty" jsonschema:"Source agent: claude-code|cursor|gemini|antigravity"`

--- a/internal/memory/model.go
+++ b/internal/memory/model.go
@@ -10,15 +10,41 @@ import (
 type MemoryType string
 
 const (
-	TypeSolution    MemoryType = "solution"
-	TypeProblem     MemoryType = "problem"
-	TypeCodePattern MemoryType = "code_pattern"
-	TypeFix         MemoryType = "fix"
-	TypeError       MemoryType = "error"
-	TypeWorkflow    MemoryType = "workflow"
-	TypeDecision    MemoryType = "decision"
-	TypeGeneral     MemoryType = "general"
+	TypeSolution     MemoryType = "solution"
+	TypeProblem      MemoryType = "problem"
+	TypeCodePattern  MemoryType = "code_pattern"
+	TypeFix          MemoryType = "fix"
+	TypeError        MemoryType = "error"
+	TypeWorkflow     MemoryType = "workflow"
+	TypeDecision     MemoryType = "decision"
+	TypeGeneral      MemoryType = "general"
+	TypeTask         MemoryType = "task"
+	TypeTechnology   MemoryType = "technology"
+	TypeCommand      MemoryType = "command"
+	TypeFileContext  MemoryType = "file_context"
+	TypeConversation MemoryType = "conversation"
+	TypeProject      MemoryType = "project"
 )
+
+// ValidTypes contains all known memory types accepted by the database.
+var ValidTypes = map[MemoryType]bool{
+	TypeSolution: true, TypeProblem: true, TypeCodePattern: true,
+	TypeFix: true, TypeError: true, TypeWorkflow: true,
+	TypeDecision: true, TypeGeneral: true, TypeTask: true,
+	TypeTechnology: true, TypeCommand: true, TypeFileContext: true,
+	TypeConversation: true, TypeProject: true,
+}
+
+// NormalizeType returns the type as-is if valid, or TypeGeneral for unknown types.
+func NormalizeType(t MemoryType) MemoryType {
+	if t == "" {
+		return TypeGeneral
+	}
+	if ValidTypes[t] {
+		return t
+	}
+	return TypeGeneral
+}
 
 type MemoryScope string
 
@@ -105,11 +131,36 @@ type RelationshipRequest struct {
 }
 
 type Stats struct {
-	TotalMemories   int            `json:"total_memories"`
-	ByType          map[string]int `json:"by_type"`
-	ByScope         map[string]int `json:"by_scope"`
-	ByAgent         map[string]int `json:"by_agent"`
-	LongTermCount   int            `json:"long_term_count"`
-	ShortTermCount  int            `json:"short_term_count"`
-	ExpiringCount   int            `json:"expiring_count"`
+	TotalMemories  int            `json:"total_memories"`
+	ByType         map[string]int `json:"by_type"`
+	ByScope        map[string]int `json:"by_scope"`
+	ByAgent        map[string]int `json:"by_agent"`
+	LongTermCount  int            `json:"long_term_count"`
+	ShortTermCount int            `json:"short_term_count"`
+	ExpiringCount  int            `json:"expiring_count"`
+}
+
+type AnalyticsData struct {
+	TotalTokensStored   int64            `json:"total_tokens_stored"`
+	TotalTokensSaved    int64            `json:"total_tokens_saved"`
+	TotalHits           int64            `json:"total_hits"`
+	HitRate             float64          `json:"hit_rate"`
+	TopAccessedMemories []MemorySummary  `json:"top_accessed_memories"`
+	TokensByAgent       map[string]int64 `json:"tokens_by_agent"`
+	Timeline            []TimelineEntry  `json:"timeline"`
+}
+
+type MemorySummary struct {
+	ID          uuid.UUID  `json:"id"`
+	Title       string     `json:"title"`
+	Type        MemoryType `json:"type"`
+	AccessCount int        `json:"access_count"`
+	TokenCount  int        `json:"token_count"`
+	AgentSource *string    `json:"agent_source,omitempty"`
+}
+
+type TimelineEntry struct {
+	Date    string `json:"date"`
+	Created int    `json:"created"`
+	Hits    int    `json:"hits"`
 }

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -60,9 +60,7 @@ func (s *Service) Store(ctx context.Context, req StoreRequest) (*Memory, error) 
 	if mem.Tags == nil {
 		mem.Tags = []string{}
 	}
-	if mem.Type == "" {
-		mem.Type = TypeGeneral
-	}
+	mem.Type = NormalizeType(mem.Type)
 	if mem.Scope == "" {
 		mem.Scope = ScopeProject
 	}
@@ -219,6 +217,10 @@ func (s *Service) GetContext(ctx context.Context, projectID string) ([]Memory, e
 
 func (s *Service) GetStats(ctx context.Context) (*Stats, error) {
 	return s.repo.GetStats(ctx)
+}
+
+func (s *Service) GetAnalytics(ctx context.Context) (*AnalyticsData, error) {
+	return s.repo.GetAnalytics(ctx)
 }
 
 func (s *Service) CleanupExpired(ctx context.Context) (int64, error) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.1.0"
+        "react-router-dom": "^7.1.0",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -847,6 +848,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1204,6 +1241,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1249,6 +1298,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1260,7 +1372,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1275,6 +1387,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1501,6 +1619,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1548,8 +1675,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1568,6 +1816,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1589,6 +1843,16 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1641,6 +1905,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1768,6 +2038,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2256,6 +2545,36 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2326,6 +2645,57 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -2557,6 +2927,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2656,12 +3032,43 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.1.0"
+    "react-router-dom": "^7.1.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -14,6 +14,7 @@ async function request(path, options = {}) {
 
 export const api = {
   getStats: () => request('/stats'),
+  getAnalytics: () => request('/analytics'),
 
   getMemory: (id) => request(`/memories/${id}`),
 

--- a/web/src/components/Layout.jsx
+++ b/web/src/components/Layout.jsx
@@ -5,6 +5,7 @@ const navItems = [
   { to: '/', label: 'Dashboard', icon: '🧠' },
   { to: '/memories', label: 'Memories', icon: '📁' },
   { to: '/search', label: 'Search', icon: '🔍' },
+  { to: '/analytics', label: 'Analytics', icon: '📊' },
 ]
 
 export default function Layout() {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -7,6 +7,7 @@ import Layout from './components/Layout'
 import Dashboard from './pages/Dashboard'
 import MemoryBrowser from './pages/MemoryBrowser'
 import Search from './pages/Search'
+import Analytics from './pages/Analytics'
 import EmptyState from './components/EmptyState'
 
 function NotFound() {
@@ -22,6 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <Route path="/" element={<Dashboard />} />
             <Route path="/memories" element={<MemoryBrowser />} />
             <Route path="/search" element={<Search />} />
+            <Route path="/analytics" element={<Analytics />} />
             <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>

--- a/web/src/pages/Analytics.jsx
+++ b/web/src/pages/Analytics.jsx
@@ -1,0 +1,239 @@
+import { useState, useEffect } from 'react'
+import { api } from '../api'
+import { TypeBadge } from '../components/Badge'
+import { StatCard as SkeletonStatCard } from '../components/Skeleton'
+import EmptyState from '../components/EmptyState'
+import {
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  PieChart, Pie, Cell, Legend,
+  BarChart, Bar,
+} from 'recharts'
+
+const AGENT_COLORS = [
+  '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#ec4899', '#14b8a6', '#f97316',
+]
+
+function formatNumber(n) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-surface-2 border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+      <div className="text-gray-400 mb-1">{label}</div>
+      {payload.map((p, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full" style={{ background: p.color }} />
+          <span className="text-gray-300">{p.name}:</span>
+          <span className="text-white font-medium">{formatNumber(p.value)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function Analytics() {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    api.getAnalytics()
+      .then(setData)
+      .catch(e => setError(e.message))
+  }, [])
+
+  if (error) {
+    return (
+      <div className="text-red-400 bg-red-900/20 border border-red-800 rounded-lg p-4 animate-fade-in">
+        <span className="font-medium">Failed to load analytics:</span> {error}
+      </div>
+    )
+  }
+
+  const statCards = [
+    { key: 'hits', icon: '🎯', label: 'Total Hits', color: 'from-brand-600 to-brand-700', value: data?.total_hits },
+    { key: 'rate', icon: '📈', label: 'Hit Rate', color: 'from-emerald-600 to-emerald-700', value: data ? `${(data.hit_rate * 100).toFixed(1)}%` : null },
+    { key: 'stored', icon: '💾', label: 'Tokens Stored', color: 'from-purple-600 to-purple-700', value: data?.total_tokens_stored },
+    { key: 'saved', icon: '⚡', label: 'Tokens Saved', color: 'from-amber-600 to-amber-700', value: data?.total_tokens_saved },
+  ]
+
+  const agentEntries = data ? Object.entries(data.tokens_by_agent).sort((a, b) => b[1] - a[1]) : []
+  const timelineData = data?.timeline?.map(e => ({
+    ...e,
+    date: e.date.slice(5), // "02-11" format
+  })) || []
+
+  return (
+    <div className="space-y-8 animate-fade-in">
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {!data ? (
+          Array.from({ length: 4 }).map((_, i) => <SkeletonStatCard key={i} />)
+        ) : (
+          statCards.map(({ key, icon, label, color, value }) => (
+            <div key={key} className="card p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className={`w-10 h-10 rounded-xl bg-gradient-to-br ${color} flex items-center justify-center text-lg shadow-lg`}>
+                  {icon}
+                </div>
+                <span className="text-xs text-gray-500 uppercase tracking-wider font-medium">{label}</span>
+              </div>
+              <div className="text-3xl font-bold text-white tabular-nums">
+                {typeof value === 'number' ? formatNumber(value) : value}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Timeline chart */}
+      <div className="card p-5">
+        <h3 className="text-sm font-semibold text-gray-300 mb-4 uppercase tracking-wider">
+          Activity — Last 30 Days
+        </h3>
+        {!data ? (
+          <div className="h-64 bg-surface-2 rounded animate-pulse-soft" />
+        ) : timelineData.length === 0 ? (
+          <EmptyState icon="📊" title="No timeline data" description="Start storing memories to see activity." />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={timelineData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id="colorCreated" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#06b6d4" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#06b6d4" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="colorHits" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+              <XAxis dataKey="date" tick={{ fill: '#94a3b8', fontSize: 11 }} tickLine={false} />
+              <YAxis tick={{ fill: '#94a3b8', fontSize: 11 }} tickLine={false} axisLine={false} />
+              <Tooltip content={<CustomTooltip />} />
+              <Area type="monotone" dataKey="created" name="Created" stroke="#06b6d4" fillOpacity={1} fill="url(#colorCreated)" strokeWidth={2} />
+              <Area type="monotone" dataKey="hits" name="Hits" stroke="#10b981" fillOpacity={1} fill="url(#colorHits)" strokeWidth={2} />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Two columns: Top memories + Agent breakdown */}
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        {/* Top accessed memories */}
+        <div className="card p-5 xl:col-span-2">
+          <h3 className="text-sm font-semibold text-gray-300 mb-4 uppercase tracking-wider">
+            Top Accessed Memories
+          </h3>
+          {!data ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-10 bg-surface-2 rounded animate-pulse-soft" />
+              ))}
+            </div>
+          ) : data.top_accessed_memories.length === 0 ? (
+            <EmptyState icon="🎯" title="No hits yet" description="Memory access counts will appear here." />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-gray-500 uppercase tracking-wider border-b border-border">
+                    <th className="pb-2 pr-4">Memory</th>
+                    <th className="pb-2 pr-4">Type</th>
+                    <th className="pb-2 pr-4 text-right">Hits</th>
+                    <th className="pb-2 pr-4 text-right">Tokens</th>
+                    <th className="pb-2 text-right">Agent</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.top_accessed_memories.map((mem, i) => (
+                    <tr key={mem.id} className="border-b border-border/50 hover:bg-surface-2/50 transition-colors">
+                      <td className="py-2.5 pr-4">
+                        <div className="flex items-center gap-2">
+                          <span className="text-gray-500 text-xs w-5">{i + 1}.</span>
+                          <span className="text-white truncate max-w-[280px]">{mem.title}</span>
+                        </div>
+                      </td>
+                      <td className="py-2.5 pr-4">
+                        <TypeBadge type={mem.type} />
+                      </td>
+                      <td className="py-2.5 pr-4 text-right tabular-nums text-brand-400 font-medium">
+                        {mem.access_count}
+                      </td>
+                      <td className="py-2.5 pr-4 text-right tabular-nums text-gray-400">
+                        {formatNumber(mem.token_count)}
+                      </td>
+                      <td className="py-2.5 text-right text-gray-500 text-xs">
+                        {mem.agent_source || 'unknown'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Agent token breakdown */}
+        <div className="card p-5">
+          <h3 className="text-sm font-semibold text-gray-300 mb-4 uppercase tracking-wider">
+            Token Savings by Agent
+          </h3>
+          {!data ? (
+            <div className="h-64 bg-surface-2 rounded animate-pulse-soft" />
+          ) : agentEntries.length === 0 ? (
+            <EmptyState icon="🤖" title="No agent data" description="Token savings per agent will appear here." />
+          ) : (
+            <>
+              <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                  <Pie
+                    data={agentEntries.map(([name, value]) => ({ name, value }))}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={80}
+                    paddingAngle={3}
+                    dataKey="value"
+                  >
+                    {agentEntries.map((_, i) => (
+                      <Cell key={i} fill={AGENT_COLORS[i % AGENT_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    content={({ active, payload }) => {
+                      if (!active || !payload?.length) return null
+                      const { name, value } = payload[0].payload
+                      return (
+                        <div className="bg-surface-2 border border-border rounded-lg px-3 py-2 text-xs shadow-xl">
+                          <div className="text-white font-medium">{name}</div>
+                          <div className="text-gray-400">{formatNumber(value)} tokens saved</div>
+                        </div>
+                      )
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="space-y-2 mt-2">
+                {agentEntries.map(([agent, tokens], i) => (
+                  <div key={agent} className="flex items-center justify-between text-xs">
+                    <div className="flex items-center gap-2">
+                      <div className="w-2.5 h-2.5 rounded-full" style={{ background: AGENT_COLORS[i % AGENT_COLORS.length] }} />
+                      <span className="text-gray-400">{agent}</span>
+                    </div>
+                    <span className="text-gray-300 tabular-nums font-medium">{formatNumber(tokens)}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **Analytics dashboard**: New `GET /api/v1/analytics` endpoint + Recharts-powered web UI with stat cards (hit rate, token savings), 30-day activity timeline, top 10 accessed memories table, and agent token breakdown pie chart
- **Memory type expansion**: Extended PostgreSQL enum with 6 new types (task, technology, command, file_context, conversation, project) for cross-agent compatibility + `NormalizeType()` fallback for unknown types
- **Update mechanism**: Added `--update` flag to `install.sh` for seamless container updates with volume preservation

## Test plan
- [x] `curl http://localhost:8420/api/v1/analytics` returns valid JSON with token metrics, timeline, top memories
- [x] Web UI at `/analytics` renders stat cards, area chart, table, and pie chart
- [x] Storing a memory with `type: "project"` succeeds (previously 500 error)
- [x] Storing a memory with unknown type falls back to `"general"`
- [x] `install.sh --update` pulls latest image and restarts container without data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)