### PR TITLE
fix: add git config for tag creation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Create Git Tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v${{ steps.version.outputs.VERSION }}" -m "Release v${{ steps.version.outputs.VERSION }}"
           git push origin "v${{ steps.version.outputs.VERSION }}"
 


### PR DESCRIPTION
Annotated tags require committer identity. The git config was removed when the CHANGELOG commit step was cleaned up.