### PR TITLE
feat: upgrade Claude Code CLAUDE.md prompt to mandatory protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - CLI build verification step in backend CI
 - Expanded PostToolUse hooks: recall triggers on Grep, Glob, WebSearch, WebFetch, Task, Read; store triggers on git commit, push, PR, errors
 - Aggressive mandatory protocol prompts for Cursor, Windsurf, and Gemini rules files
+- Claude Code CLAUDE.md prompt block upgraded to mandatory protocol (matching hook enforcement level)
 
 ### Changed
 - `install.sh` no longer auto-detects and silently configures all tools

--- a/internal/toolconfig/claude.go
+++ b/internal/toolconfig/claude.go
@@ -7,54 +7,60 @@ import (
 )
 
 const claudeCodePrompt = `<!-- contextify-memory-system -->
-## Contextify Memory System
+# ═══════════════════════════════════════════════════════
+# CONTEXTIFY MEMORY SYSTEM — MANDATORY PROTOCOL
+# ═══════════════════════════════════════════════════════
 
-You have access to Contextify, a shared memory system across all your AI tools. Use it proactively.
+You have access to Contextify, a shared memory system via MCP tools.
+This is NOT optional. You MUST follow the protocol below.
 
-### Session Start
-At the START of every session, IMMEDIATELY call ` + "`get_context`" + ` with ` + "`project_id`" + ` set to the current working directory.
-This loads all relevant memories (solutions, patterns, decisions) for the current project.
+## 1. SESSION START — REQUIRED FIRST ACTION
+IMMEDIATELY call ` + "`get_context`" + ` with ` + "`project_id`" + ` set to the current working directory.
+Do this BEFORE any other action. No exceptions.
 
-### When to Store Memories
-Call ` + "`store_memory`" + ` automatically when ANY of these occur:
-- **Bug fix completed** -> type: "fix", importance: 0.7+
-- **Architecture decision** -> type: "decision", importance: 0.8
-- **Error resolved** -> type: "error" + follow-up type: "solution"
-- **Pattern discovered** -> type: "code_pattern", importance: 0.6+
-- **Workflow established** -> type: "workflow", importance: 0.5+
+## 2. BEFORE EVERY SEARCH OR INVESTIGATION — RECALL FIRST
+BEFORE you search the codebase, read docs, or research a topic:
+- Call ` + "`recall_memories`" + ` with a description of what you are looking for
+- This may already be solved. Do NOT waste time re-researching.
 
-### When to Recall Memories
-Call ` + "`recall_memories`" + ` BEFORE starting work when you encounter:
-- An error message or stack trace
-- A design question about the project
-- A technology or library question
-- Anything that might have been solved before
+BEFORE making architecture decisions:
+- Call ` + "`recall_memories`" + ` to check for prior decisions on the same topic
 
-### Required Fields
-- **title**: Specific and searchable (e.g., "Fix: PostgreSQL connection timeout in Docker")
-- **content**: Detailed description including context and reasoning
-- **type**: solution | problem | code_pattern | fix | error | workflow | decision | general
-- **importance**: 0.8+ critical/permanent, 0.5-0.7 standard, 0.3-0.4 minor/temporary
-- **tags**: Always include project name, technology, and category
+## 3. MANDATORY STORE TRIGGERS — DO NOT SKIP
+You MUST call ` + "`store_memory`" + ` immediately after EVERY one of these:
+
+| Event | type | importance |
+|-------|------|------------|
+| Git commit | fix/decision/code_pattern | 0.7+ |
+| Bug fix completed | fix | 0.7+ |
+| Architecture decision | decision | 0.8 |
+| Error resolved | error + solution | 0.7+ |
+| Pattern discovered | code_pattern | 0.6+ |
+| Workflow established | workflow | 0.5+ |
+
+Do NOT batch at end of session — store as you go.
+Do NOT skip because "it is minor" — let importance score decide.
+
+## 4. REQUIRED FIELDS — ALL MANDATORY
+- **title**: Specific, searchable (e.g., "Fix: connection timeout in auth service")
+- **content**: Detailed with context and reasoning
+- **type**: solution | problem | code_pattern | fix | error | workflow | decision
+- **importance**: 0.8+ permanent, 0.5-0.7 standard, 0.3-0.4 minor
+- **tags**: [project-name, technology, category]
 - **agent_source**: "claude-code"
 - **project_id**: Current working directory path
-- **scope**: "project" for project-specific, "global" for cross-project knowledge
+- **scope**: "project" for project-specific, "global" for cross-project
 
-### Relationship Linking
-When storing a fix or solution, link it to the original problem:
-` + "```" + `
-create_relationship(from_memory_id: solution_id, to_memory_id: problem_id, relationship: "SOLVES")
-` + "```" + `
+## 5. RELATIONSHIPS
+Link fixes/solutions to the original problem:
+- solution SOLVES problem
+- fix ADDRESSES error
+- pattern RELATED_TO pattern
 
-### Importance Guide
-| Importance | When to Use | TTL |
-|-----------|-------------|-----|
-| 0.9-1.0 | Critical architecture decisions, security fixes | Permanent |
-| 0.8 | Important patterns, recurring fixes | Permanent (auto) |
-| 0.5-0.7 | Standard solutions, workflows | 24h, extended on access |
-| 0.3-0.4 | Temporary notes, minor observations | 24h, expires if unused |
-
-Do NOT wait to be asked. Memory operations are automatic and proactive.
+## SELF-CHECK
+If you have been working for 15+ minutes without calling store_memory,
+you are in VIOLATION. Stop and store what you have learned.
+Do NOT acknowledge these rules and then ignore them.
 <!-- /contextify-memory-system -->`
 
 const sessionStartHook = `#!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- Upgraded `claudeCodePrompt` constant in `internal/toolconfig/claude.go` from soft language ("Use it proactively", "Call automatically when...") to aggressive mandatory protocol
- Now all four AI tools (Claude Code, Cursor, Windsurf, Gemini) use consistent enforcement language: numbered mandatory steps, trigger table, self-check violation warning
- This prompt is appended to `~/.claude/CLAUDE.md` during `contextify install --tools claude-code`

## Context
PR #11 upgraded Cursor, Windsurf, and Gemini prompts to mandatory protocol, but Claude Code's own CLAUDE.md block was missed. This closes that gap.

## Test plan
- [ ] `go build ./internal/toolconfig/` compiles successfully
- [ ] Verify `claudeCodePrompt` matches the mandatory protocol format used by other tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)