### PR TITLE
chore: prepare CHANGELOG for v0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-02-12
+
 ### Added
 - Interactive setup wizard — `install.sh` now asks which AI tools to configure
 - Windsurf support (MCP via `~/.codeium/windsurf/mcp_config.json`)
@@ -70,6 +72,7 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Docker image publishing and CI/CD pipeline
 - Architecture documentation
 
-[Unreleased]: https://github.com/atakanatali/contextify/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/atakanatali/contextify/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/atakanatali/contextify/compare/v0.2.0...v0.5.3
 [0.2.0]: https://github.com/atakanatali/contextify/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/atakanatali/contextify/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Moves [Unreleased] content to [0.5.3] - 2026-02-12 section
- Resets [Unreleased] to empty for future changes
- Updates comparison links at the bottom of CHANGELOG.md

## Test plan
- [ ] Verify CHANGELOG.md formatting is correct
- [ ] Verify comparison links point to correct tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)