### PR TITLE
feat: enforce store_memory after git commits + update configs on upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,19 @@ When the user requests a release (e.g. "release v0.5.0"), before triggering the 
 2. Commit the updated `CHANGELOG.md` as part of the release PR.
 3. This must be merged to `main` **before** triggering the release workflow.
 
+## Memory Protocol (MANDATORY)
+
+After EVERY `git commit`, you MUST immediately call `store_memory` before doing anything else.
+This is not optional. Do NOT proceed to the next task, PR creation, or any other action until `store_memory` is called.
+
+- **type**: fix | decision | code_pattern | workflow
+- **tags**: include project name, technology, category
+- **importance**: 0.7+ for commits, 0.8+ for architecture decisions
+- **agent_source**: "claude-code"
+- **project_id**: current working directory
+
+Violation: If you run any tool after `git commit` that is not `store_memory`, you are in violation.
+
 ## Commit Convention
 
 Use conventional commits: `feat:`, `fix:`, `ci:`, `refactor:`, `docs:`, `chore:`, `test:`

--- a/install.sh
+++ b/install.sh
@@ -325,8 +325,28 @@ HOOKEOF
 TOOL_INFO=$(cat 2>/dev/null || echo '{}')
 TOOL_NAME=""; TOOL_INPUT=""
 if command -v jq &>/dev/null; then TOOL_NAME=$(echo "$TOOL_INFO" | jq -r '.tool_name // empty' 2>/dev/null); TOOL_INPUT=$(echo "$TOOL_INFO" | jq -r '.tool_input.command // empty' 2>/dev/null); fi
+# State machine: enforce store_memory after git commit
+if [ -f /tmp/contextify-pending-memory ]; then
+    if [ "$TOOL_NAME" = "mcp__contextify__store_memory" ]; then
+        rm -f /tmp/contextify-pending-memory
+    else
+        echo ""
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "⛔ [Contextify] VIOLATION: You ran '$TOOL_NAME' after a git commit"
+        echo "   without calling store_memory first!"
+        echo "   STOP what you are doing. Call store_memory NOW."
+        echo "═══════════════════════════════════════════════════════════════"
+        echo ""
+    fi
+fi
 if [ "$TOOL_NAME" = "Bash" ] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
-    echo "[Contextify] Commit detected. Consider storing what was fixed/added with store_memory."
+    touch /tmp/contextify-pending-memory
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "🔴 [Contextify] COMMIT DETECTED — store_memory is REQUIRED"
+    echo "   Your NEXT action MUST be store_memory."
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
 fi
 exit 0
 HOOKEOF
@@ -517,6 +537,95 @@ run_self_test() {
     ok "Self-test: Cleaned up"
 
     ok "Self-test passed!"
+}
+
+# ─── Update Tool Configs ───
+# Force-overwrite hooks, prompts, and rules for all configured tools.
+update_tool_configs() {
+    info "Updating tool configurations..."
+
+    local claude_status cursor_status windsurf_status gemini_status
+    claude_status=$(check_claude_code_status)
+    cursor_status=$(check_cursor_status)
+    windsurf_status=$(check_windsurf_status)
+    gemini_status=$(check_gemini_status)
+
+    local updated=0
+
+    if [ "$claude_status" != "not-configured" ]; then
+        # Force-overwrite hooks
+        mkdir -p "${HOOKS_DIR}"
+        if [ -f "${SCRIPT_DIR}/scripts/hooks/session-start.sh" ]; then
+            cp "${SCRIPT_DIR}/scripts/hooks/session-start.sh" "${HOOKS_DIR}/"
+            cp "${SCRIPT_DIR}/scripts/hooks/post-tool-use.sh" "${HOOKS_DIR}/"
+        fi
+        chmod +x "${HOOKS_DIR}/session-start.sh" "${HOOKS_DIR}/post-tool-use.sh" 2>/dev/null || true
+
+        # Force-overwrite CLAUDE.md contextify block
+        local claude_md="${HOME}/.claude/CLAUDE.md"
+        if [ -f "$claude_md" ] && grep -qF "$CONTEXTIFY_MARKER" "$claude_md"; then
+            # Remove old block
+            if command -v python3 &>/dev/null; then
+                python3 -c "
+import re
+with open('$claude_md', 'r') as f:
+    content = f.read()
+content = re.sub(r'\n?$CONTEXTIFY_MARKER.*?<!-- /contextify-memory-system -->\n?', '', content, flags=re.DOTALL)
+with open('$claude_md', 'w') as f:
+    f.write(content)
+"
+            fi
+        fi
+        # Re-append latest prompt
+        local prompt_content=""
+        if [ -f "${SCRIPT_DIR}/prompts/claude-code.md" ]; then
+            prompt_content=$(cat "${SCRIPT_DIR}/prompts/claude-code.md")
+        fi
+        if [ -n "$prompt_content" ]; then
+            {
+                echo ""
+                echo "$CONTEXTIFY_MARKER"
+                echo "$prompt_content"
+                echo "<!-- /contextify-memory-system -->"
+            } >> "$claude_md"
+        fi
+        ok "Claude Code configs updated"
+        updated=$((updated + 1))
+    fi
+
+    if [ "$cursor_status" != "not-configured" ]; then
+        local rules_dir="${HOME}/.cursor/rules"
+        mkdir -p "$rules_dir"
+        if [ -f "${SCRIPT_DIR}/prompts/cursorrules.md" ]; then
+            cp "${SCRIPT_DIR}/prompts/cursorrules.md" "${rules_dir}/contextify.md"
+        fi
+        ok "Cursor configs updated"
+        updated=$((updated + 1))
+    fi
+
+    if [ "$windsurf_status" != "not-configured" ]; then
+        local rules_dir="${HOME}/.codeium/windsurf/memories"
+        mkdir -p "$rules_dir"
+        if [ -f "${SCRIPT_DIR}/prompts/windsurf.md" ]; then
+            cp "${SCRIPT_DIR}/prompts/windsurf.md" "${rules_dir}/contextify.md"
+        fi
+        ok "Windsurf configs updated"
+        updated=$((updated + 1))
+    fi
+
+    if [ "$gemini_status" != "not-configured" ]; then
+        local dest="${HOME}/.contextify/gemini-instructions.md"
+        mkdir -p "${HOME}/.contextify"
+        if [ -f "${SCRIPT_DIR}/prompts/gemini.md" ]; then
+            cp "${SCRIPT_DIR}/prompts/gemini.md" "$dest"
+        fi
+        ok "Gemini configs updated"
+        updated=$((updated + 1))
+    fi
+
+    if [ "$updated" -eq 0 ]; then
+        info "No configured tools found to update."
+    fi
 }
 
 # ─── Restart Tools ───
@@ -782,6 +891,7 @@ main() {
             check_prerequisites
             update_contextify
             wait_for_health
+            update_tool_configs
             run_self_test
             ok "Contextify updated successfully!"
             exit 0

--- a/internal/toolconfig/cursor.go
+++ b/internal/toolconfig/cursor.go
@@ -61,6 +61,11 @@ you are in VIOLATION. Stop and store what you have learned.
 Do NOT acknowledge these rules and then ignore them.
 `
 
+// UpdateCursor force-overwrites Cursor rules with latest version.
+func UpdateCursor(mcpURL string) error {
+	return ConfigureCursor(mcpURL)
+}
+
 func ConfigureCursor(mcpURL string) error {
 	mcpPath := expandPath("~/.cursor/mcp.json")
 	rulesPath := expandPath("~/.cursor/rules/contextify.md")

--- a/internal/toolconfig/detect.go
+++ b/internal/toolconfig/detect.go
@@ -67,6 +67,44 @@ func CheckAllStatuses() map[ToolName]ToolStatus {
 	return statuses
 }
 
+// UpdateConfiguredTools detects which tools are already configured and
+// force-overwrites their hooks, prompts, and rules with the latest versions.
+// Returns a list of tools that were updated.
+func UpdateConfiguredTools(mcpURL string) ([]ToolName, error) {
+	var updated []ToolName
+	var firstErr error
+
+	statuses := CheckAllStatuses()
+
+	for tool, status := range statuses {
+		if status == StatusNotConfigured {
+			continue
+		}
+
+		var err error
+		switch tool {
+		case ToolClaudeCode:
+			err = UpdateClaudeCode(mcpURL)
+		case ToolCursor:
+			err = UpdateCursor(mcpURL)
+		case ToolWindsurf:
+			err = UpdateWindsurf(mcpURL)
+		case ToolGemini:
+			err = UpdateGemini()
+		}
+
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		updated = append(updated, tool)
+	}
+
+	return updated, firstErr
+}
+
 func checkClaudeCodeStatus() ToolStatus {
 	settingsPath := expandPath("~/.claude/settings.json")
 	claudeMDPath := expandPath("~/.claude/CLAUDE.md")

--- a/internal/toolconfig/gemini.go
+++ b/internal/toolconfig/gemini.go
@@ -81,6 +81,11 @@ you are in VIOLATION. Stop and store what you have learned.
 Do NOT acknowledge these rules and then ignore them.
 `
 
+// UpdateGemini force-overwrites Gemini instructions with latest version.
+func UpdateGemini() error {
+	return ConfigureGemini()
+}
+
 func ConfigureGemini() error {
 	instrPath := expandPath("~/.contextify/gemini-instructions.md")
 

--- a/internal/toolconfig/windsurf.go
+++ b/internal/toolconfig/windsurf.go
@@ -61,6 +61,11 @@ you are in VIOLATION. Stop and store what you have learned.
 Do NOT acknowledge these rules and then ignore them.
 `
 
+// UpdateWindsurf force-overwrites Windsurf rules with latest version.
+func UpdateWindsurf(mcpURL string) error {
+	return ConfigureWindsurf(mcpURL)
+}
+
 func ConfigureWindsurf(mcpURL string) error {
 	mcpPath := expandPath("~/.codeium/windsurf/mcp_config.json")
 	rulesPath := expandPath("~/.codeium/windsurf/memories/contextify.md")

--- a/prompts/claude-code.md
+++ b/prompts/claude-code.md
@@ -45,4 +45,11 @@ create_relationship(from_memory_id: solution_id, to_memory_id: problem_id, relat
 | 0.5-0.7 | Standard solutions, workflows | 24h, extended on access |
 | 0.3-0.4 | Temporary notes, minor observations | 24h, expires if unused |
 
+### CRITICAL: Git Commit → store_memory (MANDATORY)
+
+After EVERY `git commit`, you MUST immediately call `store_memory` before doing anything else.
+This is not optional. Do NOT proceed to the next task, PR creation, or any other action until `store_memory` is called.
+
+Violation: If you run any tool after `git commit` that is not `store_memory`, you are in violation.
+
 Do NOT wait to be asked. Memory operations are automatic and proactive.

--- a/scripts/hooks/post-tool-use.sh
+++ b/scripts/hooks/post-tool-use.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Contextify PostToolUse hook for Claude Code
-# Reminds the agent to store memories after git commits.
+# Enforces store_memory after git commits.
 # Installed by: install.sh → ~/.contextify/hooks/post-tool-use.sh
+
+STATE_FILE="/tmp/contextify-pending-memory.$$"
 
 # Read tool use info from stdin
 TOOL_INFO=$(cat 2>/dev/null || echo '{}')
@@ -17,9 +19,42 @@ elif command -v python3 &>/dev/null; then
     TOOL_INPUT=$(echo "$TOOL_INFO" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
 fi
 
-# Only remind after git commits
+# --- State machine: track commit → store_memory flow ---
+
+# Check if there's a pending memory from a previous commit
+if [ -f /tmp/contextify-pending-memory ]; then
+    # The previous tool was a commit. Check if THIS tool is store_memory
+    if [ "$TOOL_NAME" = "mcp__contextify__store_memory" ]; then
+        # Good — memory stored after commit
+        rm -f /tmp/contextify-pending-memory
+    else
+        # VIOLATION: something else ran after commit instead of store_memory
+        echo ""
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "⛔ [Contextify] VIOLATION: You ran '$TOOL_NAME' after a git commit"
+        echo "   without calling store_memory first!"
+        echo ""
+        echo "   STOP what you are doing. Call store_memory NOW with:"
+        echo "   - What was committed and why"
+        echo "   - type: fix | decision | code_pattern | workflow"
+        echo "   - importance: 0.7+"
+        echo "═══════════════════════════════════════════════════════════════"
+        echo ""
+        # Keep the flag so it keeps nagging
+    fi
+fi
+
+# Detect git commit and set pending flag
 if [ "$TOOL_NAME" = "Bash" ] && echo "$TOOL_INPUT" | grep -qE 'git commit'; then
-    echo "[Contextify] Commit detected. Consider storing what was fixed/added with store_memory."
+    touch /tmp/contextify-pending-memory
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "🔴 [Contextify] COMMIT DETECTED — store_memory is REQUIRED"
+    echo ""
+    echo "   Your NEXT action MUST be store_memory."
+    echo "   Do NOT proceed to any other task until memory is stored."
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
 fi
 
 # Always exit 0


### PR DESCRIPTION
## Summary
- Post-tool-use hook uses state machine to enforce `store_memory` after every `git commit` — violations trigger persistent nagging until memory is stored
- CLAUDE.md and prompt templates include mandatory `store_memory` rule
- `contextify update` and `install.sh --update` now force-overwrite all configured tool hooks, prompts, and rules with latest versions

## Test plan
- [ ] Verify post-tool-use hook creates `/tmp/contextify-pending-memory` on git commit
- [ ] Verify violation message appears when next tool is not `store_memory`
- [ ] Verify flag is cleared after `store_memory` call
- [ ] Verify `contextify update` updates tool configs for configured tools
- [ ] Verify `install.sh --update` updates tool configs
- [ ] Verify `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)