### PR TITLE
feat: CLI self-update and MCP session warning in update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Post-tool-use hook state machine — enforces `store_memory` after every `git commit` with violation nagging
 - `contextify update` and `install.sh --update` now force-overwrite tool configs (hooks, prompts, rules) with latest versions
 - `UpdateConfiguredTools()` function for centralized tool config updates
+- **CLI self-update** — `contextify update` now updates both the Docker server and the CLI binary from GitHub Releases
+  - Downloads platform-specific binary (darwin/linux, amd64/arm64), verifies it, and replaces the current binary
+  - Falls back to `sudo` if direct replacement fails (e.g., `/usr/local/bin`)
+  - `--skip-cli` flag to update server only
+- **Update confirmation prompt** — `contextify update` warns that active MCP sessions will disconnect and asks for confirmation (`y/N`)
+  - `-y` / `--yes` flag to skip the prompt (for scripts/CI)
 
 ### Changed
 - Post-tool-use hook output upgraded from soft reminder to aggressive required/violation messages

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ contextify install                      # Full setup (pull, start, configure too
 contextify start                        # Start the container
 contextify stop                         # Stop the container
 contextify restart                      # Restart the container
-contextify update                       # Update to latest version
-contextify update -v 0.4.0              # Update to specific version
+contextify update                       # Update server + CLI (with confirmation)
+contextify update -y                    # Update without confirmation prompt
+contextify update -v 0.6.0              # Update to specific version
+contextify update --skip-cli            # Update server only, keep current CLI
 contextify status                       # Show health, container, and tool status
 contextify logs                         # Show container logs
 contextify logs -f                      # Follow container logs

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,7 +32,7 @@ and interact with the memory system from the command line.`,
 	rootCmd.AddCommand(newStopCmd())
 	rootCmd.AddCommand(newRestartCmd())
 	rootCmd.AddCommand(newLogsCmd())
-	rootCmd.AddCommand(newUpdateCmd())
+	rootCmd.AddCommand(newUpdateCmd(version))
 	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newInstallCmd())
 	rootCmd.AddCommand(newUninstallCmd())

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,7 +1,14 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/atakanatali/contextify/internal/client"
@@ -10,19 +17,50 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newUpdateCmd() *cobra.Command {
+const (
+	cliReleaseBaseURL = "https://github.com/atakanatali/contextify/releases"
+)
+
+func newUpdateCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update Contextify to a new version",
-		Long: `Update Contextify by pulling a new Docker image and recreating the container.
-Data is preserved via the Docker volume.`,
-		RunE: runUpdate,
+		Short: "Update Contextify server and CLI",
+		Long: `Update Contextify by pulling a new Docker image, recreating the container,
+and updating the CLI binary to the latest release. Data is preserved via the Docker volume.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdate(cmd, args, version)
+		},
 	}
-	cmd.Flags().StringP("version", "v", "", "Target version (e.g. 0.4.0). Defaults to latest")
+	cmd.Flags().StringP("version", "v", "", "Target version (e.g. 0.6.0). Defaults to latest")
+	cmd.Flags().Bool("skip-cli", false, "Skip CLI binary update")
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	return cmd
 }
 
-func runUpdate(cmd *cobra.Command, args []string) error {
+func runUpdate(cmd *cobra.Command, args []string, currentVersion string) error {
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+
+	if !skipConfirm {
+		fmt.Println()
+		printWarn("Updating will restart the Contextify server.")
+		printWarn("Active AI agent sessions (Claude Code, Cursor, etc.) will lose their MCP connection.")
+		printWarn("You will need to start a new session after the update.")
+		fmt.Println()
+		fmt.Print("  Continue? [y/N] ")
+
+		reader := bufio.NewReader(os.Stdin)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer != "y" && answer != "yes" {
+			printInfo("Update cancelled.")
+			return nil
+		}
+		fmt.Println()
+	}
+
 	mgr := docker.NewManager(getContainerName(), getDockerImage(), getPort())
 
 	if !mgr.IsDockerAvailable() {
@@ -38,7 +76,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// Update the manager's image for pull
 	mgr.Image = targetImage
 
-	printHeader("Updating Contextify")
+	// --- Server update ---
+	printHeader("Updating Server")
 
 	// 1. Pull new image
 	printStep(fmt.Sprintf("Pulling %s...", targetImage))
@@ -78,7 +117,19 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// 6. Update tool configurations (hooks, prompts, rules)
+	printOK("Server updated.")
+
+	// --- CLI update ---
+	skipCLI, _ := cmd.Flags().GetBool("skip-cli")
+	if !skipCLI {
+		printHeader("Updating CLI")
+		if err := updateCLI(targetVersion, currentVersion); err != nil {
+			printWarn(fmt.Sprintf("CLI update failed: %v", err))
+			printInfo("You can update manually: curl -fsSL https://raw.githubusercontent.com/atakanatali/contextify/main/scripts/install-cli.sh | sh")
+		}
+	}
+
+	// --- Tool config update ---
 	printHeader("Updating Tool Configurations")
 	mcpURL := getServerURL() + "/mcp"
 	updatedTools, err := toolconfig.UpdateConfiguredTools(mcpURL)
@@ -100,4 +151,102 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	printOK("Contextify updated successfully!")
 	return nil
+}
+
+func updateCLI(targetVersion, currentVersion string) error {
+	// Determine download URL
+	asset := fmt.Sprintf("contextify-%s-%s", runtime.GOOS, runtime.GOARCH)
+	var downloadURL string
+	if targetVersion != "" {
+		downloadURL = fmt.Sprintf("%s/download/v%s/%s", cliReleaseBaseURL, targetVersion, asset)
+	} else {
+		downloadURL = fmt.Sprintf("%s/latest/download/%s", cliReleaseBaseURL, asset)
+	}
+
+	printStep(fmt.Sprintf("Downloading %s...", asset))
+
+	// Download to temp file
+	tmpFile, err := os.CreateTemp("", "contextify-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		tmpFile.Close()
+		return fmt.Errorf("download failed: HTTP %d (check if release exists)", resp.StatusCode)
+	}
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("write binary: %w", err)
+	}
+	tmpFile.Close()
+
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+
+	// Verify the downloaded binary works
+	out, err := exec.Command(tmpPath, "version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("downloaded binary is invalid: %w", err)
+	}
+	newVersion := strings.TrimSpace(string(out))
+	printStep(fmt.Sprintf("Downloaded: %s", newVersion))
+
+	// Find current binary path
+	currentBinary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("find current binary: %w", err)
+	}
+
+	// Try direct replace first, fall back to sudo
+	err = replaceFile(tmpPath, currentBinary)
+	if err != nil {
+		// Try with sudo
+		printStep("Need elevated permissions, trying sudo...")
+		sudoCmd := exec.Command("sudo", "mv", tmpPath, currentBinary)
+		sudoCmd.Stdin = os.Stdin
+		sudoCmd.Stdout = os.Stdout
+		sudoCmd.Stderr = os.Stderr
+		if err := sudoCmd.Run(); err != nil {
+			return fmt.Errorf("install binary (try: sudo mv %s %s): %w", tmpPath, currentBinary, err)
+		}
+	}
+
+	printOK(fmt.Sprintf("CLI updated: %s → %s", currentVersion, newVersion))
+	return nil
+}
+
+// replaceFile attempts to replace dst with src via rename.
+func replaceFile(src, dst string) error {
+	// Try rename (works if same filesystem and have write permission)
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+
+	// Try copy if rename fails (cross-device)
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
 }


### PR DESCRIPTION
## Summary
- `contextify update` now updates **both** the Docker server and the CLI binary from GitHub Releases
- Adds confirmation prompt before update, warning that active MCP sessions will disconnect
- New flags: `--skip-cli` (server only), `--yes`/`-y` (skip confirmation)

## Changes
- **`internal/cli/update.go`** — CLI self-update logic (download, verify, replace with sudo fallback) + y/N confirmation prompt
- **`internal/cli/root.go`** — pass version to `newUpdateCmd(version)` so CLI knows its current version
- **`README.md`** — updated CLI commands section with new flags
- **`CHANGELOG.md`** — documented new features

## Test plan
- [x] Run `contextify update` and verify y/N prompt appears
- [x] Answer `n` and verify update is cancelled
- [x] Answer `y` and verify both server and CLI update
- [x] Run `contextify update --skip-cli -y` and verify only server updates
- [x] Run `contextify update -y` in a script context
- [x] Verify `contextify version` shows new version after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)