### PR TITLE
Fix client/API contract mismatches and isolate e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ ollama_models/
 # Environment
 .env
 .env.local
+
+# Local agent/tooling caches
+.gocache/
+.claude/worktrees/

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -18,11 +18,16 @@ func newPromoteCmd() *cobra.Command {
 
 func runPromote(cmd *cobra.Command, args []string) error {
 	c := client.New(getServerURL())
-	mem, err := c.PromoteMemory(cmd.Context(), args[0])
+	mem, getErr := c.GetMemory(cmd.Context(), args[0])
+	resp, err := c.PromoteMemory(cmd.Context(), args[0])
 	if err != nil {
 		return fmt.Errorf("promote memory: %w", err)
 	}
 
-	printOK(fmt.Sprintf("Memory promoted to permanent: %s (%s)", mem.Title, mem.ID))
+	if getErr == nil && mem != nil {
+		printOK(fmt.Sprintf("Memory promoted to permanent: %s (%s)", mem.Title, resp.ID))
+		return nil
+	}
+	printOK(fmt.Sprintf("Memory promoted to permanent: %s", resp.ID))
 	return nil
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -40,11 +40,14 @@ func (c *Client) Health(ctx context.Context) error {
 }
 
 func (c *Client) StoreMemory(ctx context.Context, req StoreRequest) (*Memory, error) {
-	var mem Memory
-	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/memories", req, &mem); err != nil {
+	var result StoreResult
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/memories", req, &result); err != nil {
 		return nil, err
 	}
-	return &mem, nil
+	if result.Memory == nil {
+		return nil, fmt.Errorf("store memory: empty memory in response")
+	}
+	return result.Memory, nil
 }
 
 func (c *Client) GetMemory(ctx context.Context, id string) (*Memory, error) {
@@ -67,12 +70,12 @@ func (c *Client) DeleteMemory(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, "/api/v1/memories/"+id, nil, nil)
 }
 
-func (c *Client) PromoteMemory(ctx context.Context, id string) (*Memory, error) {
-	var mem Memory
-	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/memories/"+id+"/promote", nil, &mem); err != nil {
+func (c *Client) PromoteMemory(ctx context.Context, id string) (*PromoteResponse, error) {
+	var resp PromoteResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/memories/"+id+"/promote", nil, &resp); err != nil {
 		return nil, err
 	}
-	return &mem, nil
+	return &resp, nil
 }
 
 func (c *Client) Recall(ctx context.Context, req SearchRequest) ([]SearchResult, error) {

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -20,6 +20,16 @@ type Memory struct {
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 }
 
+type StoreResult struct {
+	Memory *Memory `json:"memory"`
+	Action string  `json:"action"`
+}
+
+type PromoteResponse struct {
+	Status string `json:"status"`
+	ID     string `json:"id"`
+}
+
 type StoreRequest struct {
 	Title       string   `json:"title"`
 	Content     string   `json:"content"`

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -91,7 +91,7 @@ func (s *Service) Store(ctx context.Context, req StoreRequest) (*StoreResult, er
 			copy(mergedFrom[1:], existing.MergedFrom)
 			mergedFrom[0] = existing.ID // track the original state
 
-			if err := s.repo.UpdateMergeFields(ctx, existing.ID, title, content, tags, importance, existing.MergedFrom, &mergedEmb); err != nil {
+			if err := s.repo.UpdateMergeFields(ctx, existing.ID, title, content, tags, importance, mergedFrom, &mergedEmb); err != nil {
 				return nil, fmt.Errorf("auto-merge update: %w", err)
 			}
 

--- a/tests/e2e/consolidation_test.go
+++ b/tests/e2e/consolidation_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 // Package e2e contains end-to-end tests that hit a running Contextify server.
 // Run with: go test ./tests/e2e/ -v -count=1
 // Requires: Contextify server running on localhost:8420


### PR DESCRIPTION
## Summary
- align Go API client StoreMemory with StoreResult response shape
- align PromoteMemory client to consume status/id response and update CLI output flow
- fix auto-merge merged_from persistence by passing the computed slice
- mark consolidation e2e tests with e2e build tag so go test ./... stays stable
- ignore local .gocache/ and .claude/worktrees/ in git

## Validation
- GOCACHE=/Users/atakan/Desktop/Projects/VibeCoding/repos/contextify/.gocache GOTMPDIR=/Users/atakan/Desktop/Projects/VibeCoding/repos/contextify/.gotmp go test ./...