### PR TITLE
Sprint 1: telemetry event pipeline foundation (CFY-101, CFY-102)

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -15,7 +16,14 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 			reqID = uuid.New().String()[:8]
 		}
 		w.Header().Set("X-Request-ID", reqID)
-		next.ServeHTTP(w, r)
+
+		ctx := context.WithValue(r.Context(), "request_id", reqID)
+		if sessionID := r.Header.Get("X-Session-ID"); sessionID != "" {
+			w.Header().Set("X-Session-ID", sessionID)
+			ctx = context.WithValue(ctx, "session_id", sessionID)
+		}
+
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/db/migrations/004_telemetry.sql
+++ b/internal/db/migrations/004_telemetry.sql
@@ -1,0 +1,33 @@
+-- Contextify: Telemetry Events
+-- Captures recall/store funnel events for analytics and quality tuning.
+
+CREATE TABLE IF NOT EXISTS memory_telemetry_events (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    event_type    TEXT NOT NULL,
+    session_id    TEXT,
+    request_id    TEXT,
+    agent_source  TEXT,
+    project_id    TEXT,
+    memory_id     UUID,
+    query_text    TEXT,
+    action        TEXT,
+    hit_count     INTEGER,
+    latency_ms    INTEGER,
+    metadata      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_event_type_created
+    ON memory_telemetry_events (event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_created
+    ON memory_telemetry_events (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_project
+    ON memory_telemetry_events (project_id);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_agent
+    ON memory_telemetry_events (agent_source);
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_session
+    ON memory_telemetry_events (session_id);

--- a/internal/memory/model.go
+++ b/internal/memory/model.go
@@ -108,21 +108,46 @@ type UpdateRequest struct {
 }
 
 type SearchRequest struct {
-	Query         string      `json:"query"`
-	Type          *MemoryType `json:"type,omitempty"`
+	Query         string       `json:"query"`
+	Type          *MemoryType  `json:"type,omitempty"`
 	Scope         *MemoryScope `json:"scope,omitempty"`
-	ProjectID     *string     `json:"project_id,omitempty"`
-	AgentSource   *string     `json:"agent_source,omitempty"`
-	Tags          []string    `json:"tags,omitempty"`
-	MinImportance *float32    `json:"min_importance,omitempty"`
-	Limit         int         `json:"limit"`
-	Offset        int         `json:"offset"`
+	ProjectID     *string      `json:"project_id,omitempty"`
+	AgentSource   *string      `json:"agent_source,omitempty"`
+	Tags          []string     `json:"tags,omitempty"`
+	MinImportance *float32     `json:"min_importance,omitempty"`
+	Limit         int          `json:"limit"`
+	Offset        int          `json:"offset"`
 }
 
 type SearchResult struct {
-	Memory     Memory  `json:"memory"`
-	Score      float64 `json:"score"`
-	MatchType  string  `json:"match_type"` // "semantic", "keyword", "hybrid"
+	Memory    Memory  `json:"memory"`
+	Score     float64 `json:"score"`
+	MatchType string  `json:"match_type"` // "semantic", "keyword", "hybrid"
+}
+
+type TelemetryEventType string
+
+const (
+	TelemetryRecallAttempt    TelemetryEventType = "recall_attempt"
+	TelemetryRecallHit        TelemetryEventType = "recall_hit"
+	TelemetryStoreOpportunity TelemetryEventType = "store_opportunity"
+	TelemetryStoreAction      TelemetryEventType = "store_action"
+)
+
+type TelemetryEvent struct {
+	ID          uuid.UUID          `json:"id"`
+	EventType   TelemetryEventType `json:"event_type"`
+	SessionID   *string            `json:"session_id,omitempty"`
+	RequestID   *string            `json:"request_id,omitempty"`
+	AgentSource *string            `json:"agent_source,omitempty"`
+	ProjectID   *string            `json:"project_id,omitempty"`
+	MemoryID    *uuid.UUID         `json:"memory_id,omitempty"`
+	QueryText   *string            `json:"query_text,omitempty"`
+	Action      *string            `json:"action,omitempty"`
+	HitCount    *int               `json:"hit_count,omitempty"`
+	LatencyMs   *int               `json:"latency_ms,omitempty"`
+	Metadata    map[string]any     `json:"metadata,omitempty"`
+	CreatedAt   time.Time          `json:"created_at"`
 }
 
 type RelationshipRequest struct {


### PR DESCRIPTION
## Scope in this PR\n- CFY-101: telemetry schema + async/non-blocking event writer\n- CFY-102: request/session attribution propagation in API + MCP paths\n\n## Implemented\n- Added telemetry table migration: memory_telemetry_events\n- Added telemetry event model/types\n- Added repository writer for telemetry events\n- Added non-blocking async telemetry emit in Store/Search paths\n- Added request_id/session_id context propagation from API middleware\n- Added request_id/session_id context propagation for MCP handler\n\n## Event types emitted\n- recall_attempt\n- recall_hit\n- store_opportunity\n- store_action\n\n## Validation\n- go test ./...\n\n## Next\n- CFY-103 funnel analytics endpoint + dashboard view\n\nCloses #22\nCloses #23