### PR TITLE
CFY-104: enforce session-start context readiness

### DIFF
--- a/internal/toolconfig/cursor.go
+++ b/internal/toolconfig/cursor.go
@@ -15,6 +15,8 @@ This is NOT optional. You MUST follow the protocol below.
 ## 1. SESSION START — REQUIRED FIRST ACTION
 IMMEDIATELY call ` + "`get_context`" + ` with the current workspace path as ` + "`project_id`" + `.
 Do this BEFORE any other action. No exceptions.
+Until ` + "`get_context`" + ` succeeds, the session is NOT READY.
+If hooks are unavailable in your environment, this manual first step is mandatory.
 
 ## 2. BEFORE EVERY SEARCH OR INVESTIGATION — RECALL FIRST
 BEFORE you search the codebase, read docs, or research a topic:

--- a/internal/toolconfig/windsurf.go
+++ b/internal/toolconfig/windsurf.go
@@ -15,6 +15,8 @@ This is NOT optional. You MUST follow the protocol below.
 ## 1. SESSION START — REQUIRED FIRST ACTION
 IMMEDIATELY call ` + "`get_context`" + ` with the current workspace path as ` + "`project_id`" + `.
 Do this BEFORE any other action. No exceptions.
+Until ` + "`get_context`" + ` succeeds, the session is NOT READY.
+If hooks are unavailable in your environment, this manual first step is mandatory.
 
 ## 2. BEFORE EVERY SEARCH OR INVESTIGATION — RECALL FIRST
 BEFORE you search the codebase, read docs, or research a topic:

--- a/prompts/claude-code.md
+++ b/prompts/claude-code.md
@@ -5,6 +5,7 @@ You have access to Contextify, a shared memory system across all your AI tools. 
 ### Session Start
 At the START of every session, IMMEDIATELY call `get_context` with `project_id` set to the current working directory.
 This loads all relevant memories (solutions, patterns, decisions) for the current project.
+Until `get_context` succeeds, the session is NOT READY and normal task work should not start.
 
 ### When to Store Memories
 Call `store_memory` automatically when ANY of these occur:

--- a/prompts/cursorrules.md
+++ b/prompts/cursorrules.md
@@ -4,6 +4,8 @@ You have access to Contextify, a shared memory system via MCP tools. Use it proa
 
 ## Session Start
 At the beginning of each session, call `get_context` with the current workspace path as `project_id`.
+Until `get_context` succeeds, the session is NOT READY and normal task work should not start.
+If hooks are unavailable in your environment, this manual `get_context` step is mandatory.
 
 ## When to Store Memories
 Store memories automatically when you:

--- a/prompts/windsurf.md
+++ b/prompts/windsurf.md
@@ -4,6 +4,8 @@ You have access to Contextify, a shared memory system via MCP tools. Use it proa
 
 ## Session Start
 At the beginning of each session, call `get_context` with the current workspace path as `project_id`.
+Until `get_context` succeeds, the session is NOT READY and normal task work should not start.
+If hooks are unavailable in your environment, this manual `get_context` step is mandatory.
 
 ## When to Store Memories
 Store memories automatically when you:


### PR DESCRIPTION
## Summary\n- enforce session readiness in Claude session-start hook via context preload attempt\n- introduce explicit NOT READY state when context preload/get_context is missing\n- enforce get_context-first behavior in post-tool-use hook with clear violation logs\n- strengthen Cursor/Windsurf/Claude prompt instructions: session is not ready until get_context succeeds\n\n## Validation\n- go test ./...\n\nCloses #25