### PR TITLE
docs: set merge policy to merge-commit (no squash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Documented repository merge policy in `CLAUDE.md`: use normal merge commits for PRs (no squash), then delete remote feature branches after merge.
+
 ## [0.7.0] - 2026-02-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,14 @@ When making a git commit, **always** update `CHANGELOG.md` before committing:
 
 3. Stage `CHANGELOG.md` together with the rest of the commit.
 
+## Merge Policy
+
+For this repository, PRs should use **normal merge commit** strategy.
+
+- Do not use squash merge.
+- Keep individual commits in history.
+- After merge, delete the remote feature branch.
+
 ### Release Preparation
 
 When the user requests a release (e.g. "release v0.5.0"), before triggering the workflow:


### PR DESCRIPTION
## Summary
- add repository merge policy to CLAUDE.md
- policy now explicitly requires normal merge commits for PRs
- explicitly disallow squash merge
- require deleting remote feature branch after merge
- update Unreleased changelog entry for this rule change

## Validation
- documentation-only change
