### PR TITLE
feat: add Claude Desktop/Cowork and Claude Chat MCP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Claude Desktop / Cowork MCP support via `npx mcp-remote` stdio bridge (`claude_desktop_config.json`)
+- Claude Chat (claude.ai) remote MCP setup guidance with manual connector instructions
+- New tool options in install wizard: `claude-desktop` and `claude-chat` (interactive menu items 2 and 3)
+- Go toolconfig: `internal/toolconfig/desktop.go` and `internal/toolconfig/chat.go`
+- Cross-platform Claude Desktop config path detection (macOS, Windows, Linux)
+- Auto-restart Claude Desktop after configuration
+
 ### Changed
+- Install wizard expanded from 4 to 6 tool options
+- `--tools` flag now accepts `claude-desktop` and `claude-chat`
+- `--all` flag includes all 6 tools
 - Documented repository merge policy in `CLAUDE.md`: use normal merge commits for PRs (no squash), then delete remote feature branches after merge.
 
 ## [0.7.0] - 2026-02-12

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -24,11 +24,11 @@ This command will:
   1. Pull the Docker image
   2. Start the Contextify container
   3. Wait for the system to be ready
-  4. Configure your AI tools (Claude Code, Cursor, Windsurf, Gemini)
+  4. Configure your AI tools (Claude Code, Claude Desktop/Cowork, Claude Chat, Cursor, Windsurf, Gemini)
   5. Run a self-test to verify everything works`,
 		RunE: runInstall,
 	}
-	cmd.Flags().StringSlice("tools", nil, "Tools to configure (claude-code,cursor,windsurf,gemini)")
+	cmd.Flags().StringSlice("tools", nil, "Tools to configure (claude-code,claude-desktop,claude-chat,cursor,windsurf,gemini)")
 	cmd.Flags().Bool("all", false, "Configure all detected tools")
 	cmd.Flags().Bool("no-test", false, "Skip self-test")
 	return cmd
@@ -228,6 +228,19 @@ func configureTool(tool toolconfig.ToolName, mcpURL string) error {
 	switch tool {
 	case toolconfig.ToolClaudeCode:
 		return toolconfig.ConfigureClaudeCode(mcpURL)
+	case toolconfig.ToolClaudeDesktop:
+		return toolconfig.ConfigureClaudeDesktop(mcpURL)
+	case toolconfig.ToolClaudeChat:
+		if err := toolconfig.ConfigureClaudeChat(mcpURL); err != nil {
+			return err
+		}
+		// Claude Chat requires manual setup via claude.ai UI
+		printInfo("Claude Chat requires manual setup:")
+		fmt.Println("    1. Go to https://claude.ai → Settings → Connectors")
+		fmt.Println("    2. Click 'Add custom connector'")
+		fmt.Printf("    3. Enter MCP URL: %s\n", mcpURL)
+		fmt.Println("    4. Enable the connector in each conversation via '+' → 'Connectors'")
+		return nil
 	case toolconfig.ToolCursor:
 		return toolconfig.ConfigureCursor(mcpURL)
 	case toolconfig.ToolWindsurf:

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -51,6 +51,14 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	_ = toolconfig.UninstallClaudeCode()
 	printOK("Claude Code configuration removed.")
 
+	printStep("Removing Claude Desktop / Cowork configuration...")
+	_ = toolconfig.UninstallClaudeDesktop()
+	printOK("Claude Desktop configuration removed.")
+
+	printStep("Removing Claude Chat configuration...")
+	_ = toolconfig.UninstallClaudeChat()
+	printOK("Claude Chat configuration removed.")
+
 	printStep("Removing Cursor configuration...")
 	_ = toolconfig.UninstallCursor()
 	printOK("Cursor configuration removed.")

--- a/internal/toolconfig/chat.go
+++ b/internal/toolconfig/chat.go
@@ -1,0 +1,78 @@
+package toolconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const claudeChatInstructions = `# Contextify Memory System — Claude Chat (claude.ai)
+
+Contextify is configured as a connector in your Claude.ai account.
+The MCP tools are available when the Contextify connector is enabled in a conversation.
+
+## How to enable Contextify in a conversation
+1. Click the "+" button at the bottom of the chat
+2. Select "Connectors"
+3. Toggle ON the "Contextify" connector
+
+## Memory Protocol
+Once enabled, follow these rules:
+
+### SESSION START
+Call ` + "`get_context`" + ` with your project path as ` + "`project_id`" + ` at the start of every conversation.
+
+### STORE MEMORIES
+Call ` + "`store_memory`" + ` after:
+- Completing a task or fixing a bug
+- Making an architecture decision
+- Discovering a reusable pattern
+- Resolving an error
+
+### RECALL MEMORIES
+Call ` + "`recall_memories`" + ` before:
+- Starting research on a new topic
+- Making architecture decisions
+- Troubleshooting an error
+
+### Required fields
+- **agent_source**: "claude-chat"
+- **project_id**: Your project path or identifier
+- **type**: solution | problem | code_pattern | fix | error | workflow | decision
+- **importance**: 0.8+ permanent, 0.5-0.7 standard, 0.3-0.4 minor
+`
+
+// ConfigureClaudeChat saves instructions and prints guidance for manual setup.
+// Claude Chat (claude.ai) requires manual configuration via Settings > Connectors.
+// There is no programmatic way to add MCP servers to claude.ai.
+func ConfigureClaudeChat(mcpURL string) error {
+	instrPath := expandPath("~/.contextify/claude-chat-instructions.md")
+
+	if err := os.MkdirAll(filepath.Dir(instrPath), 0755); err != nil {
+		return err
+	}
+
+	content := claudeChatInstructions + "\n## MCP Server URL\n" +
+		"Use this URL when adding the custom connector:\n" +
+		"  " + mcpURL + "\n"
+
+	return os.WriteFile(instrPath, []byte(content), 0644)
+}
+
+// UpdateClaudeChat is an alias for ConfigureClaudeChat (always overwrites).
+func UpdateClaudeChat(mcpURL string) error {
+	return ConfigureClaudeChat(mcpURL)
+}
+
+// UninstallClaudeChat removes the instructions file.
+func UninstallClaudeChat() error {
+	_ = os.Remove(expandPath("~/.contextify/claude-chat-instructions.md"))
+	return nil
+}
+
+func checkClaudeChatStatus() ToolStatus {
+	instrPath := expandPath("~/.contextify/claude-chat-instructions.md")
+	if fileExists(instrPath) {
+		return StatusConfigured
+	}
+	return StatusNotConfigured
+}

--- a/internal/toolconfig/desktop.go
+++ b/internal/toolconfig/desktop.go
@@ -1,0 +1,139 @@
+package toolconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const claudeDesktopPrompt = `# ═══════════════════════════════════════════════════════
+# CONTEXTIFY MEMORY SYSTEM — MANDATORY PROTOCOL
+# ═══════════════════════════════════════════════════════
+
+You have access to Contextify, a shared memory system via MCP tools.
+This is NOT optional. You MUST follow the protocol below.
+
+## 1. SESSION START — REQUIRED FIRST ACTION
+IMMEDIATELY call ` + "`get_context`" + ` with the current workspace/folder path as ` + "`project_id`" + `.
+Do this BEFORE any other action. No exceptions.
+
+## 2. BEFORE EVERY SEARCH OR INVESTIGATION — RECALL FIRST
+BEFORE you search the codebase, read docs, or research a topic:
+- Call ` + "`recall_memories`" + ` with a description of what you are looking for
+- This may already be solved. Do NOT waste time re-researching.
+
+BEFORE making architecture decisions:
+- Call ` + "`recall_memories`" + ` to check for prior decisions on the same topic
+
+## 3. MANDATORY STORE TRIGGERS — DO NOT SKIP
+You MUST call ` + "`store_memory`" + ` immediately after EVERY one of these:
+
+| Event | type | importance |
+|-------|------|------------|
+| Task completed | fix/decision/code_pattern | 0.7+ |
+| Bug fix completed | fix | 0.7+ |
+| Architecture decision | decision | 0.8 |
+| Error resolved | error + solution | 0.7+ |
+| Pattern discovered | code_pattern | 0.6+ |
+| Workflow established | workflow | 0.5+ |
+
+Do NOT batch at end of session — store as you go.
+Do NOT skip because "it is minor" — let importance score decide.
+
+## 4. REQUIRED FIELDS — ALL MANDATORY
+- **title**: Specific, searchable (e.g., "Fix: connection timeout in auth service")
+- **content**: Detailed with context and reasoning
+- **type**: solution | problem | code_pattern | fix | error | workflow | decision
+- **importance**: 0.8+ permanent, 0.5-0.7 standard, 0.3-0.4 minor
+- **tags**: [project-name, technology, category]
+- **agent_source**: "claude-desktop"
+- **project_id**: Current workspace/folder path
+- **scope**: "project" for project-specific, "global" for cross-project
+
+## 5. RELATIONSHIPS
+Link fixes/solutions to the original problem:
+- solution SOLVES problem
+- fix ADDRESSES error
+- pattern RELATED_TO pattern
+
+## SELF-CHECK
+If you have been working for 15+ minutes without calling store_memory,
+you are in VIOLATION. Stop and store what you have learned.
+Do NOT acknowledge these rules and then ignore them.
+`
+
+// claudeDesktopConfigPath returns the path to Claude Desktop's config file.
+func claudeDesktopConfigPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home(), "Library", "Application Support", "Claude", "claude_desktop_config.json")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			appData = filepath.Join(home(), "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "Claude", "claude_desktop_config.json")
+	default: // linux
+		return filepath.Join(home(), ".config", "Claude", "claude_desktop_config.json")
+	}
+}
+
+// ConfigureClaudeDesktop sets up Claude Desktop / Cowork for Contextify.
+// Uses npx mcp-remote to bridge HTTP MCP to stdio for Claude Desktop.
+func ConfigureClaudeDesktop(mcpURL string) error {
+	return configureClaudeDesktop(mcpURL, false)
+}
+
+// UpdateClaudeDesktop force-overwrites Claude Desktop config with latest version.
+func UpdateClaudeDesktop(mcpURL string) error {
+	return configureClaudeDesktop(mcpURL, true)
+}
+
+func configureClaudeDesktop(mcpURL string, _ bool) error {
+	configPath := claudeDesktopConfigPath()
+
+	// Claude Desktop only supports stdio transport via claude_desktop_config.json.
+	// Use npx mcp-remote to bridge our HTTP MCP endpoint to stdio.
+	mcpConfig := map[string]any{
+		"command": "npx",
+		"args":    []any{"mcp-remote", mcpURL},
+	}
+	if err := jsonSetNested(configPath, "mcpServers.contextify", mcpConfig); err != nil {
+		return err
+	}
+
+	// Install instructions file for Claude Desktop/Cowork
+	instrPath := expandPath("~/.contextify/claude-desktop-instructions.md")
+	if err := os.MkdirAll(filepath.Dir(instrPath), 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(instrPath, []byte(claudeDesktopPrompt), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UninstallClaudeDesktop removes Contextify configuration from Claude Desktop.
+func UninstallClaudeDesktop() error {
+	configPath := claudeDesktopConfigPath()
+	_ = jsonRemoveKey(configPath, "mcpServers.contextify")
+	_ = os.Remove(expandPath("~/.contextify/claude-desktop-instructions.md"))
+	return nil
+}
+
+func checkClaudeDesktopStatus() ToolStatus {
+	configPath := claudeDesktopConfigPath()
+	instrPath := expandPath("~/.contextify/claude-desktop-instructions.md")
+
+	hasMCP := jsonHasKey(configPath, "mcpServers.contextify")
+	hasInstr := fileExists(instrPath)
+
+	if hasMCP && hasInstr {
+		return StatusConfigured
+	}
+	if hasMCP || hasInstr {
+		return StatusPartial
+	}
+	return StatusNotConfigured
+}

--- a/internal/toolconfig/detect.go
+++ b/internal/toolconfig/detect.go
@@ -27,6 +27,15 @@ func DetectInstalledTools() []ToolName {
 		installed = append(installed, ToolClaudeCode)
 	}
 
+	// Claude Desktop / Cowork: check if config dir exists
+	configPath := claudeDesktopConfigPath()
+	if dirExists(filepath.Dir(configPath)) {
+		installed = append(installed, ToolClaudeDesktop)
+	}
+
+	// Claude Chat: always available (remote MCP via claude.ai UI)
+	installed = append(installed, ToolClaudeChat)
+
 	// Cursor: check if ~/.cursor/ exists
 	if dirExists(expandPath("~/.cursor")) {
 		installed = append(installed, ToolCursor)
@@ -48,6 +57,10 @@ func CheckStatus(tool ToolName) ToolStatus {
 	switch tool {
 	case ToolClaudeCode:
 		return checkClaudeCodeStatus()
+	case ToolClaudeDesktop:
+		return checkClaudeDesktopStatus()
+	case ToolClaudeChat:
+		return checkClaudeChatStatus()
 	case ToolCursor:
 		return checkCursorStatus()
 	case ToolWindsurf:
@@ -85,6 +98,10 @@ func UpdateConfiguredTools(mcpURL string) ([]ToolName, error) {
 		switch tool {
 		case ToolClaudeCode:
 			err = UpdateClaudeCode(mcpURL)
+		case ToolClaudeDesktop:
+			err = UpdateClaudeDesktop(mcpURL)
+		case ToolClaudeChat:
+			err = UpdateClaudeChat(mcpURL)
 		case ToolCursor:
 			err = UpdateCursor(mcpURL)
 		case ToolWindsurf:

--- a/internal/toolconfig/restart.go
+++ b/internal/toolconfig/restart.go
@@ -16,6 +16,11 @@ func RestartTool(tool ToolName) error {
 	case ToolClaudeCode:
 		// Claude Code has no programmatic restart; user must start a new session
 		return nil
+	case ToolClaudeDesktop:
+		return restartApp("Claude")
+	case ToolClaudeChat:
+		// Web-based, no restart needed
+		return nil
 	case ToolGemini:
 		// API-based, no restart needed
 		return nil
@@ -30,6 +35,8 @@ func IsToolRunning(tool ToolName) bool {
 		return isProcessRunning("Cursor")
 	case ToolWindsurf:
 		return isProcessRunning("Windsurf")
+	case ToolClaudeDesktop:
+		return isProcessRunning("Claude")
 	default:
 		return false
 	}

--- a/internal/toolconfig/types.go
+++ b/internal/toolconfig/types.go
@@ -3,10 +3,12 @@ package toolconfig
 type ToolName string
 
 const (
-	ToolClaudeCode ToolName = "claude-code"
-	ToolCursor     ToolName = "cursor"
-	ToolWindsurf   ToolName = "windsurf"
-	ToolGemini     ToolName = "gemini"
+	ToolClaudeCode    ToolName = "claude-code"
+	ToolClaudeDesktop ToolName = "claude-desktop"
+	ToolClaudeChat    ToolName = "claude-chat"
+	ToolCursor        ToolName = "cursor"
+	ToolWindsurf      ToolName = "windsurf"
+	ToolGemini        ToolName = "gemini"
 )
 
 type ToolStatus string
@@ -25,6 +27,8 @@ type Tool struct {
 
 var AllTools = []Tool{
 	{Name: ToolClaudeCode, Label: "Claude Code"},
+	{Name: ToolClaudeDesktop, Label: "Claude Desktop / Cowork"},
+	{Name: ToolClaudeChat, Label: "Claude Chat (claude.ai)"},
 	{Name: ToolCursor, Label: "Cursor"},
 	{Name: ToolWindsurf, Label: "Windsurf"},
 	{Name: ToolGemini, Label: "Gemini"},


### PR DESCRIPTION
## Summary
- Add **Claude Desktop / Cowork** MCP support via `npx mcp-remote` stdio bridge
- Add **Claude Chat (claude.ai)** remote MCP setup guidance with manual connector instructions
- Expand install wizard from 4 to 6 tool options (`claude-desktop`, `claude-chat`)

## Details

### Claude Desktop / Cowork
Claude Desktop only supports stdio transport in `claude_desktop_config.json`. Since Contextify is HTTP-based, we use `npx mcp-remote` as a bridge:

```json
{
  "mcpServers": {
    "contextify": {
      "command": "npx",
      "args": ["mcp-remote", "http://localhost:8420/mcp"]
    }
  }
}
```

- Config path: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
- Cross-platform support (macOS, Windows, Linux)
- Requires Node.js for `mcp-remote`
- Auto-restarts Claude Desktop after config

### Claude Chat (claude.ai)
No programmatic API exists for adding MCP connectors to claude.ai. The installer:
1. Saves instructions to `~/.contextify/claude-chat-instructions.md`
2. Shows step-by-step guide: Settings → Connectors → Add custom connector
3. Requires Pro, Max, Team, or Enterprise plan

### Files Changed
- **New**: `internal/toolconfig/desktop.go`, `internal/toolconfig/chat.go`
- **Modified**: `types.go`, `detect.go`, `restart.go`, `install.go`, `uninstall.go`, `install.sh`, `CHANGELOG.md`

## Test plan
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — all tests pass
- [x] `contextify install --tools claude-desktop` — configures Claude Desktop
- [x] `contextify install --tools claude-chat` — shows manual setup instructions
- [x] `./install.sh --status` — shows 6 tools with status
- [x] `contextify uninstall` — cleans up all 6 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)